### PR TITLE
Reconfigure exports and imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // index.js
-
+require = require("esm")(module)
+module.exports = require('./logic.js')
 /**
  * Required External Modules
  */

--- a/modules/dock.js
+++ b/modules/dock.js
@@ -1,3 +1,4 @@
+import { Location } from './location.js';
 export class Dock {
   //provide dock object, or use default properties:
   constructor(info = {}) {

--- a/modules/docklist.js
+++ b/modules/docklist.js
@@ -1,4 +1,5 @@
-
+import { Dock } from './dock.js';
+import { Location } from './location.js';
 //PortList
 export class DockList {
   constructor(list) {

--- a/modules/location.js
+++ b/modules/location.js
@@ -1,5 +1,3 @@
-
-
 //Location
 export class Location {
   constructor(info = {}) {
@@ -18,6 +16,13 @@ export class Location {
   }
 
   isMatch(x, y) {
-
+    if (x.isNaN || y.isNaN) return false;
+    else {
+      let validx = false;
+      let validy = false;
+      if (this.xmin <= x && x <= this.xmax) validx = true;
+      if (this.ymin <= y && y <= this.ymax) validy = true;
+      return validx && validy;
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "esm": "^3.2.25",
         "express": "^4.17.1",
         "pug": "^3.0.2"
       },
@@ -1369,6 +1370,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/etag": {
@@ -5262,6 +5271,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "etag": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "nodemon": "^2.0.7"
   },
   "dependencies": {
+    "esm": "^3.2.25",
     "express": "^4.17.1",
     "pug": "^3.0.2"
   }

--- a/test/dock.test.js
+++ b/test/dock.test.js
@@ -1,11 +1,11 @@
 // const Todos = require('../logic.js');
-import * as Todos from "../logic.js";
+import { Dock } from "../logic.js";
 import { strict as assert } from 'assert';
-// const assert = require('assert');
+// var Dock = require('../modules/dock.js');
 
 describe('Dock', function() {
   before(function() {
-    this.dock = new Todos.Dock();
+    this.dock = new Dock();
     this.obj = {};
   })
   context('#constructor()', function() {
@@ -23,7 +23,7 @@ describe('Dock', function() {
     it('preserve existing properties', function() {
       this.obj.name = 'original';
       this.dock.update(this.obj);
-      this.dock.update({next: new Todos.Dock()});
+      this.dock.update({next: new Dock()});
       assert.equal(this.obj.name, 'original')
     });
     it('merge properties passed in as an object', function() {

--- a/test/docklist.test.js
+++ b/test/docklist.test.js
@@ -1,20 +1,21 @@
-// const Todos = require('../logic.js');
-import * as Todos from "../logic.js";
+import { Dock } from "../logic.js";
+import { DockList } from "../logic.js";
 import { strict as assert } from 'assert';
 
 describe('DockList', function() {
   context('#append()', function() {
     beforeEach(function() {
-      this.list = new Todos.DockList();
-      this.first = new Todos.Dock({name: 'first'});
-      this.second = new Todos.Dock({name: 'second'});
-      this.third = new Todos.Dock({name: 'third'});
+      this.list = new DockList();
+      this.first = new Dock({name: 'first'});
+      this.second = new Dock({name: 'second'});
+      this.third = new Dock({name: 'third'});
     });
     it('should add to an empty list', function() {
       this.list.append(this.first);
       assert.equal(this.list.head, this.first);
-      assert.equal(this.list.next, null);
-      assert.equal(this.list.prev, null);
+      assert.equal(this.list.tail, this.first);
+      // assert.equal(this.list.next, null);
+      // assert.equal(this.list.prev, null);
     });
     it('should add to the end of a list with a single dock', function() {
       this.list.append(this.first);
@@ -37,9 +38,9 @@ describe('DockList', function() {
   });
   context('#pop()', function() {
     beforeEach(function() {
-      this.list = new Todos.DockList();
-      this.first = new Todos.Dock({name: 'first'});
-      this.second = new Todos.Dock({name: 'second'});
+      this.list = new DockList();
+      this.first = new Dock({name: 'first'});
+      this.second = new Dock({name: 'second'});
       this.list.append(this.first);
       this.list.append(this.second);
     });
@@ -54,12 +55,12 @@ describe('DockList', function() {
     it('should reset the tail correctly', function() {
       this.list.pop();
       assert.equal(this.list.tail, this.first);
-    })
+    });
   });
   context('#findByLoc()', function() {
 
   });
   context('#findByName()', function() {
 
-  })
-})
+  });
+});

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -1,12 +1,11 @@
-// const Todos = require('../logic.js');
-import * as Todos from "../logic.js";
+import { Location } from "../logic.js";
 import { strict as assert } from 'assert';
-// const assert = require('assert');
+
 
 describe('Location', function() {
   context('#constructor()', function() {
     beforeEach(function() {
-      this.loc = new Todos.Location();
+      this.loc = new Location();
       this.obj = {};
     });
     it('should assign null to ymin and xmax', function() {
@@ -21,7 +20,7 @@ describe('Location', function() {
   });
   context('#update()', function() {
     beforeEach(function() {
-      this.loc = new Todos.Location();
+      this.loc = new Location();
       this.obj = {};
     });
     it('preserve existing properties', function() {
@@ -38,48 +37,47 @@ describe('Location', function() {
   });
   context('#isMatch()', function() {
     beforeEach(function() {
-      this.loc = new Todos.Location();
-      this.update = {x: -2000, y: 7500, xmin: -2500, xmax: -1500, ymin: 7000, ymax: 8000};
+      this.loc = new Location({x: -2000, y: 7500, xmin: -2500, xmax: -1500, ymin: 7000, ymax: 8000});
     });
     it('return true if parameter x < xmax', function() {
-      const result = this.loc.isMatch(-2000, 0);
+      const result = this.loc.isMatch(-2000, 7000);
       assert.equal(result, true);
     });
     it('return false if parameter x > xmax', function() {
-      const result = this.loc.isMatch(-1000, 0);
+      const result = this.loc.isMatch(-1000, 8000);
       assert.equal(result, false);
     });
     it('return true if parameter x > xmin', function() {
-      const result = this.loc.isMatch(-1000, 0);
+      let result = this.loc.isMatch(-2000, 7500);
       assert.equal(result, true);
     });
     it('return false if paramter x < xmin', function() {
-      const result = this.loc.isMatch(-3000, 0);
+      const result = this.loc.isMatch(-3000, -2000);
       assert.equal(result, false);
     });
     it('return true if parameter y < ymax', function() {
-      const result = this.loc.isMatch(0, 7500);
+      const result = this.loc.isMatch(-2500, 7500);
       assert.equal(result, true);
     });
-    it('return false if parameter y > ymax'), function() {
-      const result = this.loc.isMatch(0, 8000);
+    it('return false if parameter y > ymax', function() {
+      const result = this.loc.isMatch(-1500, 8100);
       assert.equal(result, false);
-    };
-    it('return true if parameter y > ymin'), function() {
-      const result = this.loc.isMatch(0, 7500);
-      assert.equal(result, true);
-    };
-    it('return false if parameter y < ymin'), function() {
-      const result = this.loc.isMatch(0, 6000);
-      assert.equal(result, false);
-    };
-    it('return true if arguments x and y are valid'), function() {
+    });
+    it('return true if parameter y > ymin', function() {
       const result = this.loc.isMatch(-2000, 7500);
       assert.equal(result, true);
-    };
-    it('return false if arguments x and y are not valid'), function() {
-      const result = this.loc.isMatch(-3000, 8500);
+    });
+    it('return false if parameter y < ymin', function() {
+      const result = this.loc.isMatch(-2000, 6000);
+      assert.equal(result, false);
+    });
+    it('return true if arguments x and y are valid', function() {
+      const result = this.loc.isMatch(-2000, 7500);
       assert.equal(result, true);
-    };
+    });
+    it('return false if arguments x and y are not valid', function() {
+      const result = this.loc.isMatch(-3000, 8500);
+      assert.equal(result, false);
+    });
   });
 });


### PR DESCRIPTION
Add esm as a dependency to use ES6 for the import and export of class modules.

Resolve class files import, and set correct file exports for tests and to be used through logic.js.

Remove all class code from logic.js, which now just collects all class modules and exports classes for mocha testing.

All current unit tests pass.